### PR TITLE
Added timeout as a recognized variable in the config

### DIFF
--- a/izaber_wamp/__init__.py
+++ b/izaber_wamp/__init__.py
@@ -71,6 +71,7 @@ def load_config(**kwargs):
         uri_base=client_options.get('uri_base',u'com.izaber.wamp'),
         realm=client_options.get('realm',u'izaber'),
         authmethods=client_options.get('authmethods',[u'ticket']),
+        timeout=client_options.get('timeout', 10)
     )
 
     if AUTORUN and config.wamp.get('run',True):


### PR DESCRIPTION
This should allow the user to set the response timeout for WAMP calls (in seconds) using the `timeout` parameter in their `~/izaber.yaml` file. 