### PR TITLE
Fix the default URL

### DIFF
--- a/izaber_wamp/__init__.py
+++ b/izaber_wamp/__init__.py
@@ -17,7 +17,7 @@ default:
         connection:
             username: 'anonymous'
             password: 'changeme'
-            url: 'wss://nexus.izaber.com/wss'
+            url: 'wss://nexus.izaber.com/ws'
             serializer: 'cbor'
 """
 


### PR DESCRIPTION
The provided URL does not work; changing it to end with `/ws` does.